### PR TITLE
Added Laravel Mix 6 compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,12 @@
 const mix = require('laravel-mix');
+const Path = require('path');
 
 class Alias {
     register (alias, path = null) {
         const aliases = getAliasesObject(alias, path);
 
         this.aliases = Object.assign(aliases, this.aliases || {});
-        this.rootPath = global.path.resolve(__dirname, '../../');
+        this.rootPath = Path.resolve(__dirname, '../../');
     }
 
     webpackConfig (webpackConfig) {


### PR DESCRIPTION
I tried to use this package with the new Laravel Mix 6 and it complained that `global.path` did not exist.

Here is a simple fix that seems to solve the problem.

Thanks for the cool plugin 👍 